### PR TITLE
Resigning first responder for Open and Close instead of just Toggle

### DIFF
--- a/Xamarin-Sidebar/SidebarController.cs
+++ b/Xamarin-Sidebar/SidebarController.cs
@@ -155,8 +155,6 @@ namespace SidebarNavigation
 		/// </summary>
 		public void ToggleMenu()
 		{
-			if (!IsOpen && ContentAreaController != null && ContentAreaController.IsViewLoaded)
-				ContentAreaController.View.EndEditing(true);
 			if (IsOpen)
 				CloseMenu();
 			else
@@ -172,6 +170,7 @@ namespace SidebarNavigation
 				return;
 			ShowShadow(5);
 			var view = _contentAreaView;
+			view.EndEditing(true);
 			UIView.Animate(
 				_slideSpeed, 
 				0, 
@@ -198,6 +197,7 @@ namespace SidebarNavigation
 		{
 			if (!IsOpen)
 				return;
+			MenuAreaController.View.EndEditing(true);
 			var view = _contentAreaView;
 			// define the animation
 			NSAction animation = () => { view.Frame = new RectangleF (0, 0, view.Frame.Width, view.Frame.Height); };

--- a/Xamarin-Sidebar/SidebarController.cs
+++ b/Xamarin-Sidebar/SidebarController.cs
@@ -156,7 +156,7 @@ namespace SidebarNavigation
 		public void ToggleMenu()
 		{
 			if (!IsOpen && ContentAreaController != null && ContentAreaController.IsViewLoaded)
-				ResignFirstResponders(ContentAreaController.View);
+				ContentAreaController.View.EndEditing(true);
 			if (IsOpen)
 				CloseMenu();
 			else
@@ -509,18 +509,6 @@ namespace SidebarNavigation
 			if (_shouldReceiveTouch != null)
 				return _shouldReceiveTouch(gesture, touch);
 			return true;
-		}
-
-		private void ResignFirstResponders(UIView view)
-		{
-			if (view.Subviews == null)
-				return;
-			foreach (UIView subview in view.Subviews)
-			{
-				if (subview.IsFirstResponder)
-					subview.ResignFirstResponder();
-				ResignFirstResponders(subview);
-			}
 		}
 
 		#endregion

--- a/Xamarin-Sidebar/SidebarController.cs
+++ b/Xamarin-Sidebar/SidebarController.cs
@@ -235,7 +235,7 @@ namespace SidebarNavigation
 			_tapGesture.AddTarget (() => CloseMenu());
 			_tapGesture.NumberOfTapsRequired = 1;
 			_panGesture = new UIPanGestureRecognizer {
-				Delegate = new SlideoutPanDelegate(this),
+				Delegate = new SlideoutPanDelegate(),
 				MaximumNumberOfTouches = 1,
 				MinimumNumberOfTouches = 1
 			};
@@ -527,13 +527,6 @@ namespace SidebarNavigation
 
 		private class SlideoutPanDelegate : UIGestureRecognizerDelegate
 		{
-			private readonly UIViewController _controller;
-
-			public SlideoutPanDelegate (UIViewController controller)
-			{
-				_controller = controller;
-			}
-
 			public override bool ShouldReceiveTouch (UIGestureRecognizer recognizer, UITouch touch)
 			{
 				return true;


### PR DESCRIPTION
In my use case I have a SearchBar in the menu. Works great, except the keyboard is not dismissing when the menu closes. I can work around that with some ways that the menu can be closed...but simply tapping on the content area is all handled inside the SidebarController. Looking into the code I noticed the ToggleMenu method had logic to resign first responder for the content area. This doesn't help for text fields in the menu, and actually also doesnt help if you call Close direct, which is what was happening.

I ended up doing a couple things. One thing is just using EndEditing(true) instead of the recursive ResignFirstResponders. Perhaps there's a functional difference but from what I can tell it accomplishes the same thing, and searching around it looks like performance of EndEditing v. ResignFirstResponder is negligible.

The other thing was to move the EndEditing calls into OpenMenu and CloseMenu methods so that whether you use ToggleMenu or Open/Close the same logic applies. The logic actually ends editing on the menu when the menu is closing, and ends editing on the content if the menu is opening.

One other change came along for the ride in this PR, just removing an unused symbol warning.

Thanks for sharing the component - it's simple and easy to use!
